### PR TITLE
Pillar based docker users

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,36 @@ Setup a systemd timer that cleans up unused and dangling images every night by r
 ### docker.compose
 
 Install `docker-compose` package.
+
+### docker.pillar-users
+
+Populate the `docker` group with a list of usernames extracted from Salt pillar data.
+The pillar of the targeted minion should contain the following, where each subkey (`FIRSTSET`, `SECONDSET`, ...) and associated list of users may originate from a different pillar file targeted to the minion (e.g. due to overlapping wildcard matches in pillar targeting).
+
+```
+docker-users:
+    ----------
+    FIRSTSET:
+        - user_A
+        - user_B
+    SECONDSET:
+        - user_A
+        - user_C
+```
+
+The resulting list of users in the dockergroup for this example would be `user_A, user_B, user_C`.
+The given exampel pillar data would be the result of targeting both the following onto some minion:
+
+```
+docker-users:
+    FIRSTSET:
+        - user_A
+        - user_B
+```
+
+```
+docker-users:
+    SECONDSET:
+        - user_A
+        - user_C
+```

--- a/pillar-users.sls
+++ b/pillar-users.sls
@@ -1,0 +1,23 @@
+{# We expect 'docker-users' to yield a dictionary, where each key maps to a list of usernames.
+   The dictionary is the result of multiple merged pillar files targeted to this minion. The
+   value() operation turns the dict into a list of lists of users. The sum(start=[]) filter
+   is a fold that flattens this into a plain list of users and the unique filter removes
+   potentially occurring duplicates.
+
+   It is the users obligation to ensure that all users in `dockerusers` are actually present
+   on this minion. Since we do not know the way in which users are placed on minions, i.e.
+   thorugh which states, we cannot enforce this here with include directives.
+#}
+
+{% set dockerusers = pillar.get('docker-users', {}).values() | sum(start=[]) | unique %}
+
+include:
+  - docker
+
+# Add users to docker group, so they can access docker
+add_users_to_docker_group:
+  group.present:
+    - name: docker
+    - members: {{dockerusers}}
+    - require:
+      - pkg: docker


### PR DESCRIPTION
We add a state that admits flexible configuration of users in the docker group through pillar data. The actual list of users can be composed from multiple pillar files targeted to the same minion.