### PR TITLE
Add substate docker.client.config to deploy .docker/config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ See `pillar.example` for configuration options.
 Setup a systemd timer that cleans up unused and dangling images every night by running
 `docker system prune --force --all` automatically.
 
+### docker.client.config
+
+Deploys the file `~/.docker/config.json`, where `~` expands to the home dir of the user
+running the minion-service. The contents of this file are read from the pillar key
+`docker.client.config`. The main purpose here is to have a state where the salt-minion
+user is already logged into private docker registries (as recorded in the client config file).
+This in turn enables the subsequent setup of the state `docker_image.present` where the
+image in question originates from said private registries.
+
 ### docker.compose
 
 Install `docker-compose` package.

--- a/client/config.sls
+++ b/client/config.sls
@@ -1,0 +1,14 @@
+{% set USER = grains['username'] %}
+
+~/.docker:
+  file.directory:
+    - user: {{ USER }}
+    - group: {{ USER }}
+    - mode: 700
+
+~/.docker/config.json:
+  file.managed:
+    - user: {{ USER }}
+    - group: {{ USER }}
+    - mode: 600
+    - contents_pillar: docker.client.config

--- a/pillar.example
+++ b/pillar.example
@@ -14,3 +14,9 @@ docker:
   swarm:
     # Configure interface for Docker Swarm communication (defaults to eth0)
     interface: eth0
+
+  # configuring docker client settings
+
+  client:
+    config: |
+      ... Data that should show up in ~/.docker/config.json ...


### PR DESCRIPTION
We add a new substate to be able to deploy the client config, which in turn can carry the information against which private registries the salt minion user is already authenticated. This in turn allows the use of the state `docker_image.present` with images from registries that require authentication. as it turns out, the latter is not capable of automatically logging in on demand, even if the authentication credentials are provided in the pillar. The salt _module_ `dockerng.login` can digest this information and perform the login, but this functionality is not accessible when running an unattended application of the salt highstate.

personal note: we intended to use this new substate both for our preauth-profiles to be able to pull some custom images during unattended boot-up, as well as for our gitlab runner, which also needs preconfigured access to our custom registries. 