### PR TITLE
Add state for soft cleanup: only dangling state is cleaned

### DIFF
--- a/prune/docker-prune-soft.service
+++ b/prune/docker-prune-soft.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Cleanup (soft) docker images / containers
+
+[Service]
+Type=oneshot
+
+# Remove all dangling images
+ExecStart=/usr/bin/docker system prune --force

--- a/prune/docker-prune-soft.timer
+++ b/prune/docker-prune-soft.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Timer to automatically cleanup (soft) docker images / containers
+
+[Timer]
+OnCalendar=02:00
+Unit=docker-prune-soft.service
+
+[Install]
+WantedBy=basic.target

--- a/prune/soft.sls
+++ b/prune/soft.sls
@@ -1,0 +1,30 @@
+# Deploy systemd-timer to cleanup (soft) docker images / containers automatically
+docker-prune-soft.timer:
+  service.running:
+    - enable: true
+    - watch:
+      - file: /etc/systemd/system/docker-prune-soft.timer
+    - require:
+      - file: /etc/systemd/system/docker-prune-soft.timer
+      - cmd: systemctl daemon-reload
+  file.managed:
+    - name: /etc/systemd/system/docker-prune-soft.timer
+    - user: root
+    - group: root
+    - mode: 644
+    - source: salt://{{ slspath }}/docker-prune-soft.timer
+  cmd.run:
+    - name: systemctl daemon-reload
+    - onchanges:
+      - file: /etc/systemd/system/docker-prune-soft.timer
+
+/etc/systemd/system/docker-prune-soft.service:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 644
+    - source: salt://{{ slspath }}/docker-prune-soft.service
+  cmd.run:
+    - name: systemctl daemon-reload
+    - onchanges:
+      - file: /etc/systemd/system/docker-prune.service


### PR DESCRIPTION
The provided state is mostly a duplication of the already existing primary `prune` state, though the actual `docker system prune` command is run here without the `--all` flag.

The reason for wanting such a state is that a host might contain images which are neither held in a registry somewhere, nor easily rebuildable. Moreover, such images might be dormant, i.e not mapped to a currently running container. In this scenario the image cache of the host in question may be the only place where these images are stored. Meanwhile the host might be accumulating a lot of dangling state from runs that do not clean up after them. To keep some control over this actual garbage, without accidentally deleting the dormant images, the `prune` command without `--all` flag is the correct way to garbage collect such systems.

**Notes:**
  - I am aware that there is a lot of code duplication in this PR and I am happy for suggestions on how to reduce this (probably through templating and configuring the options to the actual `prune` command).
  - It might be worth to provide pillar-based access to the `--filter` option of the `prune` command as well. Not sure if this would be overkill here though ...