### PR TITLE
Do not install Docker 20.10.2 due to ipv6 issues

### DIFF
--- a/repository.sls
+++ b/repository.sls
@@ -11,3 +11,21 @@ docker_repository:
       - pkg: apt-transport-https
     - require_in:
       - pkg: docker
+
+# Make sure 20.10.2 is not installed, as it messes up binding to ipv6 on the host
+# See:
+# - https://github.com/moby/libnetwork/issues/2607
+# - https://github.com/moby/libnetwork/pull/2608
+{% if grains['os_family'] == 'Debian' %}
+/etc/apt/preferences.d/docker:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 644
+    - contents:
+      - "Package: docker-ce"
+      - "Pin: version 5:20.10.2~3-0~{{ grains['os']|lower }}-{{ grains['oscodename'] }}"
+      - "Pin-Priority: -1"
+    - require_in:
+      - pkg: docker
+{% endif %}


### PR DESCRIPTION
See: 

- https://github.com/moby/libnetwork/issues/2607
- https://github.com/moby/libnetwork/pull/2608