### PR TITLE
Add require for docker group users to ensure correct state ordering

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -29,11 +29,15 @@ docker:
 {% endif %}
 
 # Add users to docker group, so they can access docker
-{% if salt['pillar.get']('docker:users', undefined) is defined %}
+{% set dockerusers = salt['pillar.get']('docker:users', undefined) %}
+{% if dockerusers is defined %}
 add_users_to_docker_group:
   group.present:
     - name: docker
-    - members: {{ salt['pillar.get']('docker:users') }}
+    - members: {{ dockerusers }}
     - require:
       - pkg: docker
+{% for user in dockerusers %}
+      - user: {{ user }}
+{% endfor %}
 {% endif %}


### PR DESCRIPTION
This change tries to prevent the case where users are added to the docker group before said users are created as part of the same salt run. This should yield a better state application stability when a single run should yield the correct result (i.e. no need for reruns to resolve ordering problems)

Note: the approach with `defined`/`undefined` is sufficient here, since `dockerusers = []` won't cause a dangling `- require:` and therefore does not have the potential for malformed yaml (c.f. the discussion we had elsewhere on this point).  