### PR TITLE
Fix: Jinja variable undefined is undefined

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -15,7 +15,7 @@ docker:
 
 # Deploy daemon.json if options are given in pillar.
 # Make sure it's not existent if not.
-{% if salt['pillar.get']('docker:daemon') %}
+{% if salt['pillar.get']('docker:daemon') is defined %}
   file.serialize:
     - name: /etc/docker/daemon.json
     - user: root
@@ -29,7 +29,7 @@ docker:
 {% endif %}
 
 # Add users to docker group, so they can access docker
-{% if salt['pillar.get']('docker:users') %}
+{% if salt['pillar.get']('docker:users') is defined %}
 add_users_to_docker_group:
   group.present:
     - name: docker

--- a/init.sls
+++ b/init.sls
@@ -15,7 +15,7 @@ docker:
 
 # Deploy daemon.json if options are given in pillar.
 # Make sure it's not existent if not.
-{% if salt['pillar.get']('docker:daemon', undefined) is defined %}
+{% if salt['pillar.get']('docker:daemon') %}
   file.serialize:
     - name: /etc/docker/daemon.json
     - user: root
@@ -29,7 +29,7 @@ docker:
 {% endif %}
 
 # Add users to docker group, so they can access docker
-{% if salt['pillar.get']('docker:users', undefined) is defined %}
+{% if salt['pillar.get']('docker:users') %}
 add_users_to_docker_group:
   group.present:
     - name: docker

--- a/init.sls
+++ b/init.sls
@@ -15,7 +15,7 @@ docker:
 
 # Deploy daemon.json if options are given in pillar.
 # Make sure it's not existent if not.
-{% if salt['pillar.get']('docker:daemon') is defined %}
+{% if salt['pillar.get']('docker:daemon', None) != none %}
   file.serialize:
     - name: /etc/docker/daemon.json
     - user: root
@@ -29,7 +29,7 @@ docker:
 {% endif %}
 
 # Add users to docker group, so they can access docker
-{% if salt['pillar.get']('docker:users') is defined %}
+{% if salt['pillar.get']('docker:users', None) != none %}
 add_users_to_docker_group:
   group.present:
     - name: docker


### PR DESCRIPTION
This Pull request fixes the issue:  
```
----------
    Rendering SLS '...' failed: Jinja variable 'undefined' is undefined; line 18

---
# Deploy daemon.json if options are given in pillar.
# Make sure it's not existent if not.
{% if salt['pillar.get']('docker:daemon', undefined) is defined %}    <======================
  file.serialize:
    - name: /etc/docker/daemon.json
    - user: root
    - group: root
    - mode: 644
[...]
```