### PR TITLE
Change pkg installed syntax to align with docs

### DIFF
--- a/login.sls
+++ b/login.sls
@@ -5,7 +5,8 @@ include:
   - docker
 
 install_pip_for_custom_python_modules:
-  pkg.installed: [python3-pip]
+  pkg.installed:
+    - name: python3-pip
 
 install_python_lib_for_docker_via_pip:
   pip.installed:


### PR DESCRIPTION
The present array syntax of the pkg.installed sate in `docker.login` SLS causes the followiing rather unhelpful error message:

```
local:
    Data failed to compile:
----------
    Too many functions declared in state 'pkg' in SLS 'docker.login'
```

This change aligns the syntax with the documentation at https://docs.saltproject.io/en/latest/ref/states/all/salt.states.pkg.html#salt.states.pkg.installed and fixes the above error.