### PR TITLE
Ensure docker config directory is present

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -22,6 +22,7 @@ docker:
     - group: root
     - mode: 644
     - formatter: json
+    - makedirs: true
     - dataset_pillar: docker:daemon
 {% else %}
   file.absent:


### PR DESCRIPTION
With docker 23.0, `/etc/docker` is no longer created by default: https://github.com/docker/cli/commit/f87d7ed8647065a09a299fa078e59e8cbc794ca2

It has also impacted projects like docker-machine which rely on existence of the directory https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/merge_requests/102