### PR TITLE
Dnsmasq should strictly follow the nameserver order in resolv.conf

### DIFF
--- a/dnsmasq.sls
+++ b/dnsmasq.sls
@@ -13,6 +13,8 @@ dnsmasq:
       - "listen-address=172.17.0.1"
       # Do not load /etc/hosts
       - "no-hosts"
+      # Strictly follow the nameserver order in resolv.conf
+      - strict-order
   service.running:
     - enable: true
     - watch:


### PR DESCRIPTION
To prevent dnsmasq from choosing an upstream server, follow the order in resolv.conf instead.

dnsmasq docs:
By default, dnsmasq will send queries to any of the upstream servers it knows about and tries to favour servers that are known to be up. Setting this flag forces dnsmasq to try each query with each server strictly in the order they appear in /etc/resolv.conf