### PR TITLE
Make dnsmasq cache size configurable

### DIFF
--- a/dnsmasq.sls
+++ b/dnsmasq.sls
@@ -15,6 +15,10 @@ dnsmasq:
       - no-hosts
       # Strictly follow the nameserver order in resolv.conf
       - strict-order
+      # Bump up cache size for better performance on systems with enough memory
+      {% if salt['pillar.get']('dnsmasq:cache-size') %}
+      - cache-size={{ salt['pillar.get']('dnsmasq:cache-size') }}
+      {% endif %}
   service.running:
     - enable: true
     - watch:

--- a/dnsmasq.sls
+++ b/dnsmasq.sls
@@ -8,11 +8,11 @@ dnsmasq:
     - contents:
       # Explicitly bind dnsmasq to the docker0 interface
       # upstream DNS servers from /etc/resolv.conf will be used
-      - "bind-interfaces"
-      - "interface=docker0"
-      - "listen-address=172.17.0.1"
+      - bind-interfaces
+      - interface=docker0
+      - listen-address=172.17.0.1
       # Do not load /etc/hosts
-      - "no-hosts"
+      - no-hosts
       # Strictly follow the nameserver order in resolv.conf
       - strict-order
   service.running:

--- a/pillar.example
+++ b/pillar.example
@@ -77,3 +77,6 @@ docker-machine:
     -----BEGIN RSA PRIVATE KEY-----
     [...]
     -----END RSA PRIVATE KEY-----
+
+dnsmasq:
+  cache-size: 1000


### PR DESCRIPTION
Having a configurable cache size would allow utilizing the local cache more effectively, default value of 150 is too low. Cache honors the ttl values so its safe to use.

>    -c, --cache-size=<cachesize>
>           Set  the size of dnsmasq's cache. The default is 150 names. Setting the cache size to zero disables caching. Note:
 >          huge cache size impacts performance.
 
 