### PR TITLE
Disable sevice reload using "docker:reload" pillar

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -8,7 +8,7 @@ docker:
   service.running:
     - name: docker
     - enable: true
-    - reload: true
+    - reload: {{ pillar['docker']['reload']|default('true') }}
     - watch:
       - pkg: docker
       - file: /etc/docker/daemon.json

--- a/pillar.example
+++ b/pillar.example
@@ -21,6 +21,8 @@ docker:
     volumes: false # Remove unused volumes as well. Default: false
     on_calendar: 02:00 # 02:00 (Default): systemd timer configuration for cleanup frequency
 
+  # Force restart instead of reload which is needed with some configuration options
+  reload: False
 
 # Registry credentials for the docker.login state (if used)
 #
@@ -80,3 +82,5 @@ docker-machine:
 
 dnsmasq:
   cache-size: 1000
+
+


### PR DESCRIPTION
Some docker configuration options like userns-remap, metrics-addr require a restart for new configuration to take effect, with a reload they are silently required. Having an interactive pillar which can be used to force restart can be helpful in these cases.