### PR TITLE
Improve getting docker.reload

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -8,7 +8,7 @@ docker:
   service.running:
     - name: docker
     - enable: true
-    - reload: {{ pillar.get('docker').get('reload') | default('true') }}
+    - reload: {{ salt['pillar.get']('docker:reload', true)  }}
     - watch:
       - pkg: docker
       - file: /etc/docker/daemon.json

--- a/init.sls
+++ b/init.sls
@@ -8,7 +8,7 @@ docker:
   service.running:
     - name: docker
     - enable: true
-    - reload: {{ pillar['docker']['reload']|default('true') }}
+    - reload: {{ pillar.get('docker').get('reload') | default('true') }}
     - watch:
       - pkg: docker
       - file: /etc/docker/daemon.json


### PR DESCRIPTION
Without this we will have a keyerror in pillar["docker"] or pillar["docker"]["reload"] which will exit instead of reaching the "default" if `docker` or `docker.reload` is missing in the pillar